### PR TITLE
Allow user-defined local MathJax installation in lieu of CDN

### DIFF
--- a/SimpleMathJax.class.php
+++ b/SimpleMathJax.class.php
@@ -22,7 +22,7 @@ class SimpleMathJax {
 	}
 
 	static function loadJS(&$out, &$skin ) {
-		global $wgSimpleMathJaxSize, $wgSimpleMathJaxChem;
+		global $wgSimpleMathJaxSize, $wgSimpleMathJaxChem, $wgLocalMathJaxDir;
 
 		$config = [
 			'messageStyle' => 'none',
@@ -33,14 +33,27 @@ class SimpleMathJax {
 		];
 		$configJs = json_encode($config, JSON_UNESCAPED_SLASHES);
 
-		$script = <<<HEREDOC
+		if ( $wgLocalMathJaxDir ) {
+			$script = <<<HEREDOC
+<style>.MathJax_Display{display:inline !important;}
+.mathjax-wrapper{display:none;font-size:${wgSimpleMathJaxSize}%;}</style>
+<script type='text/x-mathjax-config'>MathJax.Hub.Config(${configJs});MathJax.Hub.Queue(function(){\$('.mathjax-wrapper').show();});</script>
+<script src='${wgLocalMathJaxDir}/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
+HEREDOC;
+		} else {
+			$script = <<<HEREDOC
 <style>.MathJax_Display{display:inline !important;}
 .mathjax-wrapper{display:none;font-size:${wgSimpleMathJaxSize}%;}</style>
 <script type='text/x-mathjax-config'>MathJax.Hub.Config(${configJs});MathJax.Hub.Queue(function(){\$('.mathjax-wrapper').show();});</script>
 <script src='//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 HEREDOC;
+		}
 		if( $wgSimpleMathJaxChem ) {
-			$script .= "<script src='//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/extensions/TeX/mhchem.js'></script>";
+			if ( $wgLocalMathJaxDir ) {
+				$script .="<script src='${wgLocalMathJaxDir}/extensions/TeX/mhchem.js'></script>";
+			} else {
+				$script .= "<script src='//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/extensions/TeX/mhchem.js'></script>";
+			}
 		}
 		$out->addScript( $script );
 		return true;

--- a/SimpleMathJax.class.php
+++ b/SimpleMathJax.class.php
@@ -22,7 +22,7 @@ class SimpleMathJax {
 	}
 
 	static function loadJS(&$out, &$skin ) {
-		global $wgSimpleMathJaxSize, $wgSimpleMathJaxChem, $wgLocalMathJaxDir;
+		global $wgSimpleMathJaxSize, $wgSimpleMathJaxChem, $wgSimpleMathJaxLocalDir;
 
 		$config = [
 			'messageStyle' => 'none',
@@ -33,12 +33,12 @@ class SimpleMathJax {
 		];
 		$configJs = json_encode($config, JSON_UNESCAPED_SLASHES);
 
-		if ( $wgLocalMathJaxDir ) {
+		if ( $wgSimpleMathJaxLocalDir ) {
 			$script = <<<HEREDOC
 <style>.MathJax_Display{display:inline !important;}
 .mathjax-wrapper{display:none;font-size:${wgSimpleMathJaxSize}%;}</style>
 <script type='text/x-mathjax-config'>MathJax.Hub.Config(${configJs});MathJax.Hub.Queue(function(){\$('.mathjax-wrapper').show();});</script>
-<script src='${wgLocalMathJaxDir}/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
+<script src='${wgSimpleMathJaxLocalDir}/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 HEREDOC;
 		} else {
 			$script = <<<HEREDOC
@@ -49,8 +49,8 @@ HEREDOC;
 HEREDOC;
 		}
 		if( $wgSimpleMathJaxChem ) {
-			if ( $wgLocalMathJaxDir ) {
-				$script .="<script src='${wgLocalMathJaxDir}/extensions/TeX/mhchem.js'></script>";
+			if ( $wgSimpleMathJaxLocalDir ) {
+				$script .="<script src='${wgSimpleMathJaxLocalDir}/extensions/TeX/mhchem.js'></script>";
 			} else {
 				$script .= "<script src='//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/extensions/TeX/mhchem.js'></script>";
 			}


### PR DESCRIPTION
This allows a user to set the variable '$wgSimpleMathJaxLocalDir' to a MathJax installation directory on the server. The variable should point to a valid MathJax installation directory relative to the server root.

For example, if the directory `MathJax-2.7.1` contains the `MathJax.js` script, one would add to their `LocalSettings.php` the following line:

    $wgSimpleMathJaxLocalDir = '/MathJax-2.7.1';

and their mediawiki instance should now render math using MathJax installed on their server rather than on a CDN. **Note** that the leading '/' is important!