### PR TITLE
Add manifest_version to extension.json

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -30,5 +30,6 @@
 	"ResourceFileModulePaths": {
 		"localBasePath": "modules",
 		"remoteExtPath": "SimpleMathJax/modules"
-	}
+	},
+	"manifest_version": 1
 }


### PR DESCRIPTION
Fixes "Deprecated: Use of SimpleMathJax's extension.json or skin.json does not have manifest_version was deprecated in MediaWiki 1.29"