### PR TITLE
Enabled SimpleMathJax for MobileFrontend

### DIFF
--- a/SimpleMathJax_body.php
+++ b/SimpleMathJax_body.php
@@ -9,7 +9,11 @@ class SimpleMathJax {
 	public static function setup( Parser $parser ) {
 		global $wgOut, $wgSmjUseCDN, $wgSmjSize, $wgSmjUseChem, $wgSmjInlineMath;
 
-		$wgOut->addModules( $wgSmjUseCDN ? 'ext.SmjCDN' : 'ext.SmjLocal' );
+		$smjModule = $wgSmjUseCDN ? 'ext.SmjCDN' : 'ext.SmjLocal'; 
+		$wgOut->addModules( $smjModule );
+		// MobileFrontend requires explicit cloned modules targeting mobile
+		$wgOut->addModules( $smjModule . ".mobile" );
+
 		$wgOut->addJsConfigVars( 'wgSmjSize', $wgSmjSize );
 		$wgOut->addJsConfigVars( 'wgSmjUseChem', $wgSmjUseChem );
 		$wgSmjInlineMath[] = ["[math]","[/math]"];

--- a/extension.json
+++ b/extension.json
@@ -20,7 +20,9 @@
 	},
 	"ResourceModules": {
 		"ext.SmjCDN": { "scripts": "ext.SmjCDN.js" },
-		"ext.SmjLocal": { "scripts": "ext.SmjLocal.js" }
+		"ext.SmjLocal": { "scripts": "ext.SmjLocal.js" },
+		"ext.SmjCDN.mobile": { "scripts": "ext.SmjCDN.js", "targets": "mobile" },
+		"ext.SmjLocal.mobile": { "scripts": "ext.SmjLocal.js", "targets": "mobile" }
 	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "modules",


### PR DESCRIPTION
Fixes #15: Mediawiki 1.31.1 - MobileFrontend - Don't render formulas

The are some preparations needed in order to enable an extension for MobileFrontend.
It's mandatory to register cloned ResourceModules targeting 'mobile' explicitly.
See: https://www.mediawiki.org/wiki/ResourceLoader/Writing_a_MobileFrontend_friendly_ResourceLoader_module#Enabling_your_existing_modules