### PR TITLE
Adds the autoload extension, for auto dynamic loading of other extensions

### DIFF
--- a/modules/ext.SmjCDN.js
+++ b/modules/ext.SmjCDN.js
@@ -1,6 +1,6 @@
 $.getScript( '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js',
 	function () {
-		var extensions = ["tex2jax.js","TeX/AMSmath.js"];
+		var extensions = ["tex2jax.js","TeX/AMSmath.js","TeX/autoload-all.js"];
 		if( mw.config.get('wgSmjUseChem') ) extensions.push("TeX/mhchem.js");
 		MathJax.Hub.Config({
 			messageStyle: "none",

--- a/modules/ext.SmjLocal.js
+++ b/modules/ext.SmjLocal.js
@@ -1,7 +1,7 @@
 $.getScript( mw.config.get('wgExtensionAssetsPath') + '/SimpleMathJax/modules/MathJax/MathJax.js',
 	function () {
 		MathJax.Ajax.config.root = mw.config.get('wgExtensionAssetsPath') + '/SimpleMathJax/modules/MathJax';
-		var extensions = ["tex2jax.js","TeX/AMSmath.js"];
+		var extensions = ["tex2jax.js","TeX/AMSmath.js","TeX/autoload-all.js"];
 		if( mw.config.get('wgSmjUseChem') ) extensions.push("TeX/mhchem.js");
 		MathJax.Hub.Config({
 			messageStyle: "none",


### PR DESCRIPTION
Small change, that is adding the [autoload-all](extension](http://docs.mathjax.org/en/latest/tex.html#autoload-all)) to the list.

Because the extensions are not configurable at the moment in SimpleMathJax, including autoload-all allows to use [extended symbols listed on this page](http://docs.mathjax.org/en/latest/tex.html#supported-latex-commands) without having to modify the undocumented files.