### PR TITLE
Make span around [math] block marker configurable

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -55,3 +55,16 @@ If you want to disable MathJax context menu, set `$wgSmjEnableMenu`.
 wfLoadExtension( 'SimpleMathJax' );
 $wgSmjEnableMenu = false;
 ```
+
+# Hooks
+The hook `SimpleMathJaxAttributes` is available to add attributes to the span around the math. This hook provides you with the opportunity to ensure that your own code does not interfere with MathJax's rendering of math.
+
+For instance, if Lingo's JS functions are called before MathJax is invoked, then it is possible that Lingo will change the text so that MathJax could no longer render the math.
+
+Lingo understands that [it should not touch anything inside an element with the class `noglossary`](https://www.mediawiki.org/wiki/Extension:Lingo#Excluding_text_from_markup) so the following code can be used to keep Lingo from ruining math:
+```PHP
+$wfHook['SimpleMathJaxAttributes']
+	= function ( array &attributes, string $tex ) {
+		$attributes['class'] = 'noglossary';
+	}
+```

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -33,6 +33,9 @@ class SimpleMathJaxHooks {
 	private static function renderTex($tex, $parser) {
 		$parser->getOutput()->addModules( 'ext.SimpleMathJax' );
 		$parser->getOutput()->addModules( 'ext.SimpleMathJax.mobile' ); // For MobileFrontend
-		return ["<span style='opacity:.5'>[math]${tex}[/math]</span>", 'markerType'=>'nowiki'];
+		$attributes = [ "style" => "opacity:.5" ];
+		Hooks::run( "SimpleMathJaxAttr", [ &$attributes, $tex ] );
+		$element = Html::Element( "span", $attributes, "[math]{$tex}[/math]" );
+		return [$element, 'markerType'=>'nowiki'];
 	}
 }

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -13,16 +13,16 @@ class SimpleMathJaxHooks {
 		$wgOut->addJsConfigVars( 'wgSmjScale', $wgSmjScale );
 		$wgOut->addJsConfigVars( 'wgSmjEnableMenu', $wgSmjEnableMenu );
 		$wgOut->addJsConfigVars( 'wgSmjDisplayAlign', $wgSmjDisplayAlign );
-		
+
 		$parser->setHook( 'math', __CLASS__ . '::renderMath' );
 		if( $wgSmjUseChem ) $parser->setHook( 'chem', __CLASS__ . '::renderChem' );	}
-	
+
 	public static function renderMath($tex, array $args, Parser $parser, PPFrame $frame ) {
 		global $wgSmjWrapDisplaystyle;
 		$tex = str_replace('\>', '\;', $tex);
 		$tex = str_replace('<', '\lt ', $tex);
 		$tex = str_replace('>', '\gt ', $tex);
-		if( $wgSmjWrapDisplaystyle ) $tex = "\displaystyle{ $tex }"; 
+		if( $wgSmjWrapDisplaystyle ) $tex = "\displaystyle{ $tex }";
 		return self::renderTex($tex, $parser);
 	}
 
@@ -31,13 +31,8 @@ class SimpleMathJaxHooks {
 	}
 
 	private static function renderTex($tex, $parser) {
-		$parser->getOutput()->addModules( 'ext.SimpleMathJax' ); 
+		$parser->getOutput()->addModules( 'ext.SimpleMathJax' );
 		$parser->getOutput()->addModules( 'ext.SimpleMathJax.mobile' ); // For MobileFrontend
 		return ["<span style='opacity:.5'>[math]${tex}[/math]</span>", 'markerType'=>'nowiki'];
 	}
 }
-
-
-
-
-

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -34,7 +34,7 @@ class SimpleMathJaxHooks {
 		$parser->getOutput()->addModules( 'ext.SimpleMathJax' );
 		$parser->getOutput()->addModules( 'ext.SimpleMathJax.mobile' ); // For MobileFrontend
 		$attributes = [ "style" => "opacity:.5" ];
-		Hooks::run( "SimpleMathJaxAttr", [ &$attributes, $tex ] );
+		Hooks::run( "SimpleMathJaxAttributes", [ &$attributes, $tex ] );
 		$element = Html::Element( "span", $attributes, "[math]{$tex}[/math]" );
 		return [$element, 'markerType'=>'nowiki'];
 	}


### PR DESCRIPTION
We would like to add `class="noglossary"` to the `span` tag around the `[math]` block to keep the [Lingo](https://www.mediawiki.org/wiki/Extension:Lingo#Excluding_text_from_markup) extension from marking up math.

Other people may find it helpful to add attributes other attributes to the element.