### PR TITLE
fix: addModules even when there is no <math>

### DIFF
--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -1,4 +1,4 @@
-<?php
+ <?php
 class SimpleMathJaxHooks {
 
 	public static function onParserFirstCallInit( Parser $parser ) {
@@ -13,6 +13,8 @@ class SimpleMathJaxHooks {
 		$wgOut->addJsConfigVars( 'wgSmjScale', $wgSmjScale );
 		$wgOut->addJsConfigVars( 'wgSmjEnableMenu', $wgSmjEnableMenu );
 		$wgOut->addJsConfigVars( 'wgSmjDisplayAlign', $wgSmjDisplayAlign );
+		$wgOut->addModules( 'ext.SimpleMathJax' );
+		$wgOut->addModules( 'ext.SimpleMathJax.mobile' ); // For MobileFrontend
 
 		$parser->setHook( 'math', __CLASS__ . '::renderMath' );
 		if( $wgSmjUseChem ) $parser->setHook( 'chem', __CLASS__ . '::renderChem' );	}
@@ -31,8 +33,6 @@ class SimpleMathJaxHooks {
 	}
 
 	private static function renderTex($tex, $parser) {
-		$parser->getOutput()->addModules( 'ext.SimpleMathJax' );
-		$parser->getOutput()->addModules( 'ext.SimpleMathJax.mobile' ); // For MobileFrontend
 		$attributes = [ "style" => "opacity:.5" ];
 		Hooks::run( "SimpleMathJaxAttributes", [ &$attributes, $tex ] );
 		$element = Html::Element( "span", $attributes, "[math]{$tex}[/math]" );

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -13,8 +13,8 @@ class SimpleMathJaxHooks {
 		$wgOut->addJsConfigVars( 'wgSmjScale', $wgSmjScale );
 		$wgOut->addJsConfigVars( 'wgSmjEnableMenu', $wgSmjEnableMenu );
 		$wgOut->addJsConfigVars( 'wgSmjDisplayAlign', $wgSmjDisplayAlign );
-		$wgOut->addModules( 'ext.SimpleMathJax' );
-		$wgOut->addModules( 'ext.SimpleMathJax.mobile' ); // For MobileFrontend
+		$wgOut->addModules( [ 'ext.SimpleMathJax' ] );
+		$wgOut->addModules( [ 'ext.SimpleMathJax.mobile' ] ); // For MobileFrontend
 
 		$parser->setHook( 'math', __CLASS__ . '::renderMath' );
 		if( $wgSmjUseChem ) $parser->setHook( 'chem', __CLASS__ . '::renderChem' );	}


### PR DESCRIPTION
In version 0.7.x, the module will always be loaded even without any `<math>` tag. But in the master code, it will only be loaded when there are one or more `<math>` tags, which prevents the formulas of many pages that only use `$` from being loaded correctly. 

Maybe introduced from c4bd866.

Fix #36 