### PR TITLE
Mobile fix

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SimpleMathJax",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"author": "jmnote",
 	"url": "https://www.mediawiki.org/wiki/Extension:SimpleMathJax",
 	"description": "render TeX between <code><nowiki><math></nowiki></code> and <code><nowiki></math></nowiki></code>",
@@ -24,7 +24,8 @@
 	},
 	"ResourceModules": {
 		"ext.SimpleMathJax": {
-			"scripts": ["resources/ext.SimpleMathJax.js"]
+			"scripts": ["resources/ext.SimpleMathJax.js"],
+			"targets": ["desktop", "mobile"]
 		}
 	},
 	"ResourceFileModulePaths": {

--- a/resources/ext.SimpleMathJax.js
+++ b/resources/ext.SimpleMathJax.js
@@ -1,4 +1,4 @@
-mw.hook( 'wikipage.categories' ).add( function ( $content ) {
+mw.hook( 'wikipage.content' ).add( function ( $content ) {
 window.MathJax = {
   tex: {
     inlineMath: mw.config.get('wgSmjExtraInlineMath').concat([['[math]','[/math]']]),


### PR DESCRIPTION
Hi! Here's a fix to make SimpleMathJax work on mobile. Apparently the issue was that the main JS file didn't have the "mobile" target, but even after fixing that, it seems the "wikipage.categories" hook doesn't fire on mobile (reasonable, since categories aren't displayed on Minerva skin) so I changed it for "wikipage.content" and now it seems to work fine on mobile and desktop alike, see https://www.appropedia.org/How_to_measure_stream_flow_rate for proof. Thanks for this useful extension!!