### PR TITLE
Fix path to ext.SimpleMathJax.js in ResourceModules (#1)

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -30,7 +30,7 @@
 	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "",
-		"remoteExtPath": "SimpleMathJax/resources"
+		"remoteExtPath": "SimpleMathJax"
 	},
 	"manifest_version": 2
 }


### PR DESCRIPTION
Mediawiki tries to load extensions/SimpleMathJax/resources/resources/ext.SimpleMathJax.js file when ResourceLoader in debug mode, the patch fixes the path