### PR TITLE
Use HookContainer instead of deprecated Hooks class

### DIFF
--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -34,7 +34,7 @@ class SimpleMathJaxHooks {
 
 	private static function renderTex($tex, $parser) {
 		$hookContainer = MediaWiki\MediaWikiServices::getInstance()->getHookContainer();
-		$attributes = [ "style" => "opacity:.5", "class" => "smj-containter" ];
+		$attributes = [ "style" => "opacity:.5", "class" => "smj-container" ];
 		$hookContainer->run( "SimpleMathJaxAttributes", [ &$attributes, $tex ] );
 		$element = Html::Element( "span", $attributes, "[math]{$tex}[/math]" );
 		return [$element, 'markerType'=>'nowiki'];

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -33,8 +33,9 @@ class SimpleMathJaxHooks {
 	}
 
 	private static function renderTex($tex, $parser) {
+		$hookContainer = MediaWiki\MediaWikiServices::getInstance()->getHookContainer();
 		$attributes = [ "style" => "opacity:.5" ];
-		Hooks::run( "SimpleMathJaxAttributes", [ &$attributes, $tex ] );
+		$hookContainer->run( "SimpleMathJaxAttributes", [ &$attributes, $tex ] );
 		$element = Html::Element( "span", $attributes, "[math]{$tex}[/math]" );
 		return [$element, 'markerType'=>'nowiki'];
 	}

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -34,7 +34,7 @@ class SimpleMathJaxHooks {
 
 	private static function renderTex($tex, $parser) {
 		$hookContainer = MediaWiki\MediaWikiServices::getInstance()->getHookContainer();
-		$attributes = [ "style" => "opacity:.5" ];
+		$attributes = [ "style" => "opacity:.5", "class" => "smj-containter" ];
 		$hookContainer->run( "SimpleMathJaxAttributes", [ &$attributes, $tex ] );
 		$element = Html::Element( "span", $attributes, "[math]{$tex}[/math]" );
 		return [$element, 'markerType'=>'nowiki'];


### PR DESCRIPTION
Hooks is removed on 1.42, thus the extension would stop working. Use HookContainer instead.

I know nothing of PHP actually, but it currently seems to work?