### PR TITLE
explicitly import Html class

### DIFF
--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -1,4 +1,5 @@
 <?php
+use MediaWiki\Html\Html;
 class SimpleMathJaxHooks {
 
 	public static function onParserFirstCallInit( Parser $parser ) {


### PR DESCRIPTION
Since MediaWiki 1.44, the extension errors due to being unable to resolve the Html class. This is resolved by importing it explicitly, which was not required by earlier versions of MediaWiki.