### PR TITLE
add wgSmjIgnoreHtmlClass option and make delimiter disabled in commen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ wfLoadExtension( 'SimpleMathJax' );
 $wgSmjExtraInlineMath = [["$","$"],["\\(","\\)"]];
 ```
 
+Since version 0.8.7, inlineMath and blockMath are ignored in edit summaries and diffs. To restore the previous behavior, set `$wgSmjIgnoreHtmlClass`.
+```PHP
+wfLoadExtension( 'SimpleMathJax' );
+$wgSmjExtraInlineMath = [["$","$"],["\\(","\\)"]];
+$wgSmjIgnoreHtmlClass = "mathjax_ignore";
+```
+
 If you want to disable MathJax context menu, set `$wgSmjEnableMenu`.
 ```PHP
 wfLoadExtension( 'SimpleMathJax' );

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -4,13 +4,14 @@ class SimpleMathJaxHooks {
 
 	public static function onParserFirstCallInit( Parser $parser ) {
 		global $wgOut, $wgSmjUseCdn, $wgSmjUseChem, $wgSmjEnableMenu,
-			$wgSmjDisplayMath, $wgSmjExtraInlineMath,
+			$wgSmjDisplayMath, $wgSmjExtraInlineMath, $wgSmjIgnoreHtmlClass,
 			$wgSmjScale, $wgSmjDisplayAlign;
 
 		$wgOut->addJsConfigVars( 'wgSmjUseCdn', $wgSmjUseCdn );
 		$wgOut->addJsConfigVars( 'wgSmjUseChem', $wgSmjUseChem );
 		$wgOut->addJsConfigVars( 'wgSmjDisplayMath', $wgSmjDisplayMath );
 		$wgOut->addJsConfigVars( 'wgSmjExtraInlineMath', $wgSmjExtraInlineMath );
+		$wgOut->addJsConfigVars( 'wgSmjIgnoreHtmlClass', $wgSmjIgnoreHtmlClass );
 		$wgOut->addJsConfigVars( 'wgSmjScale', $wgSmjScale );
 		$wgOut->addJsConfigVars( 'wgSmjEnableMenu', $wgSmjEnableMenu );
 		$wgOut->addJsConfigVars( 'wgSmjDisplayAlign', $wgSmjDisplayAlign );

--- a/extension.json
+++ b/extension.json
@@ -14,6 +14,7 @@
 		"SmjUseChem": {"value":true, "description":"true to enabled chem tag"},
 		"SmjDisplayMath": {"value":[], "description":"MathJax.tex.displayMath"},
 		"SmjExtraInlineMath": {"value":[], "description":"MathJax.tex.inlineMath"},
+		"SmjIgnoreHtmlClass": {"value":"mathjax_ignore|comment|diff-(context|addedline|deletedline)", "description":"MathJax.options.ignoreHtmlClass"},
 		"SmjScale": {"value":1, "description":"MathJax.chtml.scale"},
 		"SmjEnableMenu": {"value":true, "description":"MathJax.options.enableMenu"},
 		"SmjDisplayAlign": {"value":"left", "description":"MathJax.chtml.displayAlign"},

--- a/resources/ext.SimpleMathJax.js
+++ b/resources/ext.SimpleMathJax.js
@@ -108,6 +108,9 @@ window.MathJax = {
       Zeta: "{\\mathrm{Z}}"
     }
   },
+  options: {
+    ignoreHtmlClass: mw.config.get('wgSmjIgnoreHtmlClass')
+  },
   chtml: {
     scale: mw.config.get('wgSmjScale'),
     displayAlign: mw.config.get('wgSmjDisplayAlign')


### PR DESCRIPTION
…t and diff

You can revert to the previous behavior by setting the newly added option.
If you install without changing the options, only the behavior of the [math][/math] format will be affected.

Fixes #46