### PR TITLE
DirectMathJax option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ wfLoadExtension( 'SimpleMathJax' );
 | ------------------------ | -------------------------------- | ------------------------- | --------------------------- |
 | `$wgSmjUseCdn`           | use CDN or local scripts         | true                      | false                       |
 | `$wgSmjUseChem`          | enable chem tag                  | true                      | false                       |
+| `$wgSmjDirectMathJax`    | which ones can be written directly  | "full"                 | "none"                      |
 | `$wgSmjEnableMenu`       | MathJax.options.enableMenu       | true                      | false                       |
 | `$wgSmjDisplayMath`      | MathJax.tex.displayMath          | []                        | [['$$','$$'],['\\[','\\]']] |
 | `$wgSmjExtraInlineMath`  | MathJax.tex.inlineMath           | []                        | [['\\(', '\\)']]            |
@@ -64,10 +65,16 @@ wfLoadExtension( 'SimpleMathJax' );
 $wgSmjEnableMenu = false;
 ```
 
-Since version 0.8.8, by enabling `$wgSmjEnableHtmlAttributes`, the `display` attribute of the `<math>` tag will work, and the `class` and `id` attributes of the `<math>` tag will be carried over to the `<span>` tag.
+Since version 0.8.8, by enabling `$wgSmjEnableHtmlAttributes`, the `display` attribute of the `<math>` tag will work, and the `class`, `id` and `title` attributes of the `<math>` tag will be carried over to the `<span>` tag.
 ```PHP
 wfLoadExtension( 'SimpleMathJax' );
 $wgSmjEnableHtmlAttributes = true;
+```
+
+In version 0.8.9, an option was added to make it completely dedicated to `<math>` and `<chem>`. Setting `$wgSmjDirectMathJax` to `env` disables `\ref{}` and escaping of `$`, while setting it to `none` disables all delimiters, including `[math]`, making it mandatory to enclose all TeX expressions in `<math>` or `<chem>`.
+```PHP
+wfLoadExtension( 'SimpleMathJax' );
+$wgSmjDirectMathJax = "none";
 ```
 
 # Hooks

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ wfLoadExtension( 'SimpleMathJax' );
 $wgSmjEnableHtmlAttributes = true;
 ```
 
-In version 0.8.9, an option was added to make it completely dedicated to `<math>` and `<chem>`. Setting `$wgSmjDirectMathJax` to `env` disables `\ref{}` and escaping of `$`, while setting it to `none` disables all delimiters, including `[math]`, making it mandatory to enclose all TeX expressions in `<math>` or `<chem>`.
+In version 0.8.9, an option was added to make it completely dedicated to `<math>` and `<chem>`. Setting `$wgSmjDirectMathJax` to `env` disables `\ref{}` and escaping of `$`, while setting it to `none` disables all delimiters, including `[math]`, making it mandatory to enclose all TeX expressions in `<math>` or `<chem>` (and `$wgSmjDisplayMath`, `$wgSmjExtraInlineMath`, `$wgSmjIgnoreHtmlClass`, etc. will become meaningless).
 ```PHP
 wfLoadExtension( 'SimpleMathJax' );
 $wgSmjDirectMathJax = "none";

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -46,7 +46,6 @@ class SimpleMathJaxHooks {
 				$tex = "\\textstyle{ $tex }";
 				break;
 			case "block":
-				$tex = "\\displaystyle{ $tex }";
 				break;
 			default:
 				return self::renderError('SimpleMathJax: Invalid attribute value: display="' . $args["display"] . '"');

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -32,7 +32,12 @@ class SimpleMathJaxHooks {
 			$tex = str_replace('<', '\lt ', $tex);
 			$tex = str_replace('>', '\gt ', $tex);
 		}
-		if( !isset($args["display"]) ) {
+		if( isset($args["inline-block"]) ) {
+			if( isset($args["display"]) ) {
+				return self::renderError('SimpleMathJax: Do not use the inline-block attribute and the display attribute together on the same element.');
+			}
+			$tex = "\\displaystyle{ $tex }";
+		} else if( !isset($args["display"]) ) {
 			if( $wgSmjWrapDisplaystyle ) $tex = "\\displaystyle{ $tex }";
 		} else switch ($args["display"]) {
 			case "":

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -3,12 +3,13 @@ use MediaWiki\Html\Html;
 class SimpleMathJaxHooks {
 
 	public static function onParserFirstCallInit( Parser $parser ) {
-		global $wgOut, $wgSmjUseCdn, $wgSmjUseChem, $wgSmjEnableMenu,
+		global $wgOut, $wgSmjUseCdn, $wgSmjUseChem, $wgSmjDirectMathJax, $wgSmjEnableMenu,
 			$wgSmjDisplayMath, $wgSmjExtraInlineMath, $wgSmjIgnoreHtmlClass,
 			$wgSmjScale, $wgSmjDisplayAlign, $wgSmjEnableHtmlAttributes;
 
 		$wgOut->addJsConfigVars( 'wgSmjUseCdn', $wgSmjUseCdn );
 		$wgOut->addJsConfigVars( 'wgSmjUseChem', $wgSmjUseChem );
+		$wgOut->addJsConfigVars( 'wgSmjDirectMathJax', $wgSmjDirectMathJax );
 		$wgOut->addJsConfigVars( 'wgSmjDisplayMath', $wgSmjDisplayMath );
 		$wgOut->addJsConfigVars( 'wgSmjExtraInlineMath', $wgSmjExtraInlineMath );
 		$wgOut->addJsConfigVars( 'wgSmjIgnoreHtmlClass', $wgSmjIgnoreHtmlClass );

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -74,7 +74,7 @@ class SimpleMathJaxHooks {
 			if( isset($args[$tag]) ) $attributes[$tag] = $args[$tag];
 		}
 		$hookContainer->run( "SimpleMathJaxAttributes", [ &$attributes, $tex ] );
-		if( $wgSmjEnableHtmlAttributes && !isset($args["debug"]) ) {
+		if( $wgSmjEnableHtmlAttributes && !isset($args["smj-debug"]) ) {
 			$attributes["class"] .= " smj-container";
 		}
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SimpleMathJax",
-	"version": "0.8.8",
+	"version": "0.8.9",
 	"author": "jmnote",
 	"url": "https://www.mediawiki.org/wiki/Extension:SimpleMathJax",
 	"description": "render TeX between <code><nowiki><math></nowiki></code> and <code><nowiki></math></nowiki></code>",

--- a/extension.json
+++ b/extension.json
@@ -12,6 +12,7 @@
 	"config": {
 		"SmjUseCdn": {"value":true, "description":"true to load mathjax from CDN"},
 		"SmjUseChem": {"value":true, "description":"true to enabled chem tag"},
+		"SmjDirectMathJax": {"value":"full", "description":"env to disable escapes, none to only math and chem tags"},
 		"SmjDisplayMath": {"value":[], "description":"MathJax.tex.displayMath"},
 		"SmjExtraInlineMath": {"value":[], "description":"MathJax.tex.inlineMath"},
 		"SmjIgnoreHtmlClass": {"value":"mathjax_ignore|comment|diff-(context|addedline|deletedline)", "description":"MathJax.options.ignoreHtmlClass"},

--- a/resources/ext.SimpleMathJax.js
+++ b/resources/ext.SimpleMathJax.js
@@ -3,6 +3,9 @@ window.MathJax = {
   tex: {
     inlineMath: mw.config.get('wgSmjExtraInlineMath').concat([['[math]','[/math]']]),
     displayMath: mw.config.get('wgSmjDisplayMath'),
+    processEnvironments: true,
+    processRefs: mw.config.get('wgSmjDirectMathJax') == 'full',
+    processEscapes: mw.config.get('wgSmjDirectMathJax') == 'full',
     packages: mw.config.get('wgSmjUseChem') ? {'[+]': ['mhchem']} : {},
     macros: {
       AA: "{\u00c5}",
@@ -123,6 +126,7 @@ window.MathJax = {
     load: mw.config.get('wgSmjUseChem') ? ['[tex]/mhchem'] : []
   },
   startup: {
+    elements: mw.config.get('wgSmjDirectMathJax') == 'none' ? ["span.smj-container"] : null,
     pageReady: () => {
       return MathJax.startup.defaultPageReady().then(() => {
         $(mw.config.get('wgSmjEnableHtmlAttributes') ? "span.smj-container > .MathJax" : ".MathJax").parent().css('opacity',1);


### PR DESCRIPTION
#### Which issue this PR fixes / What this PR does / Why we need it

I will call the path where MathJax directly renders the TeX notation written directly in the main text 'DirectMathJax', and I will add a new option to control it.

`$wgSmjDirectMathJax = "full"` (default): Operation equivalent to the current version.
`$wgSmjDirectMathJax = "env"`: Disable `processEscapes` and `processRefs`.
`$wgSmjDirectMathJax = "none"`: Only process `<math>` and `<chem>`.

- https://github.com/users/dummy-index/projects/1/views/1?pane=issue&itemId=145359601
- https://github.com/users/dummy-index/projects/1/views/1?pane=issue&itemId=145348912
- a part of https://github.com/users/dummy-index/projects/1/views/1?pane=issue&itemId=145350499


#### Checklist
<!-- Mark with [x] -->
- [x] `extension.json` version bumped

<!-- If this PR adds new variables or changes usage, please update README.md -->
