### PR TITLE
Conditional config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ wfLoadExtension( 'SimpleMathJax' );
 | `$wgSmjEnableMenu`       | MathJax.options.enableMenu       | true                      | false                       |
 | `$wgSmjDisplayMath`      | MathJax.tex.displayMath          | []                        | [['$$','$$'],['\\[','\\]']] |
 | `$wgSmjExtraInlineMath`  | MathJax.tex.inlineMath           | []                        | [['\\(', '\\)']]            |
-| `$wgSmjIgnoreHtmlClass`  | MathJax.options.ignoreHtmlClass  | "mathjax_ignore\|comment\|<br>diff-(context\|<br>addedline\|deletedline)" | "mathjax_ignore"            |
+| `$wgSmjIgnoreHtmlClass`  | MathJax.options.ignoreHtmlClass  | "mathjax_ignore\|comment\|<br>diff-(context\|<br>addedline\|deletedline)" | "mathjax_ignore" |
 | `$wgSmjScale`            | MathJax.chtml.scale              | 1                         | 1.5                         |
 | `$wgSmjDisplayAlign`     | MathJax.chtml.displayAlign       | "center"                  | "left"                      |
 | `$wgSmjWrapDisplaystyle` | wrap with displaystyle on `<math>`  | true                   | false                       |
 | `$wgSmjEnableHtmlAttributes` | process attributes of math tag  | false                  | true                        |
+| `$wgSmjConfigByRevision` | switch the configuration according to the article's revision  | [] | [['upto'=>1048576,<br>'wgSmjDisplayAlign'<br>=>'left']] |
 
 If you want to change font size, set `$wgSmjScale`.
 ```PHP
@@ -75,6 +76,16 @@ In version 0.8.9, an option was added to make it completely dedicated to `<math>
 ```PHP
 wfLoadExtension( 'SimpleMathJax' );
 $wgSmjDirectMathJax = "none";
+```
+
+By using $wgSmjConfigByRevision, you can apply different settings to an article's revisions up to a certain point and to revisions after that. This allows past revisions to be displayed with the settings that were in place at the time. Only the keys written inside the [] are overwritten. Preview, History and SpecialPages are treated as base cases that do not apply this setting.
+```PHP
+wfLoadExtension( 'SimpleMathJax' );
+$wgSmjDirectMathJax = "none";    #To match the preview with the actual rendering, write the latest settings in the base case
+$wgSmjConfigByRevision = [
+	["upto"=>50000, "wgSmjDirectMathJax"=>"full"],
+	["since"=>50001, "upto"=>60000, "wgSmjDirectMathJax"=>"env"]
+];
 ```
 
 # Hooks

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For instance, if Lingo's JS functions are called before MathJax is invoked, then
 Lingo understands that [it should not touch anything inside an element with the class `noglossary`](https://www.mediawiki.org/wiki/Extension:Lingo#Excluding_text_from_markup) so the following code can be used to keep Lingo from ruining math:
 ```PHP
 $wgHooks['SimpleMathJaxAttributes'][]
-	= function ( array &$attributes, string $tex ) {
+	= function ( array &$attributes, string $tex, array $args = [] ) {
 		$attributes['class'] .= ' noglossary';
 	};
 ```

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -5,7 +5,7 @@ class SimpleMathJaxHooks {
 	public static function onParserFirstCallInit( Parser $parser ) {
 		global $wgOut, $wgSmjUseCdn, $wgSmjUseChem, $wgSmjDirectMathJax, $wgSmjEnableMenu,
 			$wgSmjDisplayMath, $wgSmjExtraInlineMath, $wgSmjIgnoreHtmlClass,
-			$wgSmjScale, $wgSmjDisplayAlign, $wgSmjEnableHtmlAttributes;
+			$wgSmjScale, $wgSmjDisplayAlign;
 
 		$wgOut->addJsConfigVars( 'wgSmjUseCdn', $wgSmjUseCdn );
 		$wgOut->addJsConfigVars( 'wgSmjUseChem', $wgSmjUseChem );
@@ -16,7 +16,6 @@ class SimpleMathJaxHooks {
 		$wgOut->addJsConfigVars( 'wgSmjScale', $wgSmjScale );
 		$wgOut->addJsConfigVars( 'wgSmjEnableMenu', $wgSmjEnableMenu );
 		$wgOut->addJsConfigVars( 'wgSmjDisplayAlign', $wgSmjDisplayAlign );
-		$wgOut->addJsConfigVars( 'wgSmjEnableHtmlAttributes', $wgSmjEnableHtmlAttributes );
 		$wgOut->addModules( [ 'ext.SimpleMathJax' ] );
 		$wgOut->addModules( [ 'ext.SimpleMathJax.mobile' ] ); // For MobileFrontend
 
@@ -61,20 +60,16 @@ class SimpleMathJaxHooks {
 	}
 
 	private static function renderTex($tex, $parser, $args) {
-		global $wgSmjEnableHtmlAttributes;
 
 		$hookContainer = MediaWiki\MediaWikiServices::getInstance()->getHookContainer();
 		$attributes = [ "style" => "opacity:.5" ];
 		$attributes["class"] = ($args["class"] ?? '');
-		if( !$wgSmjEnableHtmlAttributes ) {
-			$attributes["class"] .= " smj-container";
-		}
 		$inherit_tags = [ "id", "title", "lang", "dir" ];
 		foreach( $inherit_tags as $tag ) {
 			if( isset($args[$tag]) ) $attributes[$tag] = $args[$tag];
 		}
-		$hookContainer->run( "SimpleMathJaxAttributes", [ &$attributes, $tex ] );
-		if( $wgSmjEnableHtmlAttributes && !isset($args["smj-debug"]) ) {
+		$hookContainer->run( "SimpleMathJaxAttributes", [ &$attributes, $tex, $args ] );
+		if( !isset($attributes["smj-debug"]) && !isset($args["smj-debug"]) ) {
 			$attributes["class"] .= " smj-container";
 		}
 

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -38,7 +38,7 @@ class SimpleMathJaxHooks {
 		$wgOut->addModules( [ 'ext.SimpleMathJax.mobile' ] ); // For MobileFrontend
 
 		$parser->setHook( 'math', __CLASS__ . '::renderMath' );
-		if( $wgSmjUseChem ) $parser->setHook( 'chem', __CLASS__ . '::renderChem' );	}
+		if( self::$useChem ) $parser->setHook( 'chem', __CLASS__ . '::renderChem' );	}
 
 	public static function renderMath($tex, array $args, Parser $parser, PPFrame $frame ) {
 		if( !self::$enableHtmlAttributes ) $args = [];

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -1,21 +1,39 @@
 <?php
 use MediaWiki\Html\Html;
 class SimpleMathJaxHooks {
+	private static $useChem;
+	private static $wrapDisplaystyle;
+	private static $enableHtmlAttributes;
 
 	public static function onParserFirstCallInit( Parser $parser ) {
 		global $wgOut, $wgSmjUseCdn, $wgSmjUseChem, $wgSmjDirectMathJax, $wgSmjEnableMenu,
 			$wgSmjDisplayMath, $wgSmjExtraInlineMath, $wgSmjIgnoreHtmlClass,
-			$wgSmjScale, $wgSmjDisplayAlign;
+			$wgSmjScale, $wgSmjDisplayAlign, $wgSmjWrapDisplaystyle,
+			$wgSmjEnableHtmlAttributes, $wgSmjConfigByRevision;
 
-		$wgOut->addJsConfigVars( 'wgSmjUseCdn', $wgSmjUseCdn );
-		$wgOut->addJsConfigVars( 'wgSmjUseChem', $wgSmjUseChem );
-		$wgOut->addJsConfigVars( 'wgSmjDirectMathJax', $wgSmjDirectMathJax );
-		$wgOut->addJsConfigVars( 'wgSmjDisplayMath', $wgSmjDisplayMath );
-		$wgOut->addJsConfigVars( 'wgSmjExtraInlineMath', $wgSmjExtraInlineMath );
-		$wgOut->addJsConfigVars( 'wgSmjIgnoreHtmlClass', $wgSmjIgnoreHtmlClass );
-		$wgOut->addJsConfigVars( 'wgSmjScale', $wgSmjScale );
-		$wgOut->addJsConfigVars( 'wgSmjEnableMenu', $wgSmjEnableMenu );
-		$wgOut->addJsConfigVars( 'wgSmjDisplayAlign', $wgSmjDisplayAlign );
+		$globalvars = [ "wgSmjUseCdn", "wgSmjUseChem", "wgSmjDirectMathJax",
+				"wgSmjDisplayMath", "wgSmjExtraInlineMath", "wgSmjIgnoreHtmlClass",
+				"wgSmjScale", "wgSmjEnableMenu", "wgSmjDisplayAlign" ];
+		foreach( $globalvars as $varname ) {
+			$wgOut->addJsConfigVars( $varname, $$varname );
+		}
+		self::$wrapDisplaystyle = $wgSmjWrapDisplaystyle;
+		self::$enableHtmlAttributes = $wgSmjEnableHtmlAttributes;
+
+		$articlerev = (int)$wgOut->getRevisionId();
+		foreach ($wgSmjConfigByRevision as $confset) {
+			if ($articlerev == 0) break;
+			if (!isset($confset["upto"]) && !isset($confset["since"])) continue;
+			if (isset($confset["upto"]) && $confset["upto"] < $articlerev) continue;
+			if (isset($confset["since"]) && $confset["since"] > $articlerev) continue;
+			foreach( $globalvars as $varname ) {
+				if( isset($confset[$varname]) ) $wgOut->addJsConfigVars( $varname, $confset[$varname] );
+			}
+			if (isset($confset["wgSmjWrapDisplaystyle"]) ) self::$wrapDisplaystyle = $confset["wgSmjWrapDisplaystyle"];
+			if (isset($confset["wgSmjEnableHtmlAttributes"]) ) self::$enableHtmlAttributes = $confset["wgSmjEnableHtmlAttributes"];
+		}
+		self::$useChem = $wgOut->getJsConfigVars()["wgSmjUseChem"];
+
 		$wgOut->addModules( [ 'ext.SimpleMathJax' ] );
 		$wgOut->addModules( [ 'ext.SimpleMathJax.mobile' ] ); // For MobileFrontend
 
@@ -23,9 +41,7 @@ class SimpleMathJaxHooks {
 		if( $wgSmjUseChem ) $parser->setHook( 'chem', __CLASS__ . '::renderChem' );	}
 
 	public static function renderMath($tex, array $args, Parser $parser, PPFrame $frame ) {
-		global $wgSmjWrapDisplaystyle, $wgSmjEnableHtmlAttributes;
-
-		if( !$wgSmjEnableHtmlAttributes ) $args = [];
+		if( !self::$enableHtmlAttributes ) $args = [];
 		if( !isset($args["chem"]) ) {
 			$tex = str_replace('\>', '\;', $tex);
 			$tex = str_replace('<', '\lt ', $tex);
@@ -37,7 +53,7 @@ class SimpleMathJaxHooks {
 			}
 			$tex = "\\displaystyle{ $tex }";
 		} else if( !isset($args["display"]) ) {
-			if( $wgSmjWrapDisplaystyle ) $tex = "\\displaystyle{ $tex }";
+			if( self::$wrapDisplaystyle ) $tex = "\\displaystyle{ $tex }";
 		} else switch ($args["display"]) {
 			case "":
 				break;
@@ -53,9 +69,7 @@ class SimpleMathJaxHooks {
 	}
 
 	public static function renderChem($tex, array $args, Parser $parser, PPFrame $frame ) {
-		global $wgSmjEnableHtmlAttributes;
-
-		if( !$wgSmjEnableHtmlAttributes ) $args = [];
+		if( !self::$enableHtmlAttributes ) $args = [];
 		return self::renderTex("\\ce{ $tex }", $parser, $args);
 	}
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SimpleMathJax",
-	"version": "0.8.9",
+	"version": "0.8.10",
 	"author": "jmnote",
 	"url": "https://www.mediawiki.org/wiki/Extension:SimpleMathJax",
 	"description": "render TeX between <code><nowiki><math></nowiki></code> and <code><nowiki></math></nowiki></code>",
@@ -20,7 +20,8 @@
 		"SmjEnableMenu": {"value":true, "description":"MathJax.options.enableMenu"},
 		"SmjDisplayAlign": {"value":"left", "description":"MathJax.chtml.displayAlign"},
 		"SmjWrapDisplaystyle": {"value":true, "description":"true to wrap with displaystyle"},
-		"SmjEnableHtmlAttributes": {"value":false, "description":"true to process attributes of math tag"}
+		"SmjEnableHtmlAttributes": {"value":false, "description":"true to process attributes of math tag"},
+		"SmjConfigByRevision": {"value":[], "description":"switch the configuration"}
 	},
 	"Hooks": {
 		"ParserFirstCallInit": "SimpleMathJaxHooks::onParserFirstCallInit"

--- a/resources/ext.SimpleMathJax.js
+++ b/resources/ext.SimpleMathJax.js
@@ -116,7 +116,7 @@ window.MathJax = {
   },
   options: {
     ignoreHtmlClass: mw.config.get('wgSmjIgnoreHtmlClass'),
-    processHtmlClass: mw.config.get('wgSmjEnableHtmlAttributes') ? "mathjax_process|smj-container" : "mathjax_process"
+    processHtmlClass: "mathjax_process|smj-container"
   },
   chtml: {
     scale: mw.config.get('wgSmjScale'),
@@ -129,7 +129,7 @@ window.MathJax = {
     elements: mw.config.get('wgSmjDirectMathJax') == 'none' ? ["span.smj-container"] : null,
     pageReady: () => {
       return MathJax.startup.defaultPageReady().then(() => {
-        $(mw.config.get('wgSmjEnableHtmlAttributes') ? "span.smj-container > .MathJax" : ".MathJax").parent().css('opacity',1);
+        $("span.smj-container > .MathJax").parent().css('opacity',1);
       });
     }
   }


### PR DESCRIPTION
#### Which issue this PR fixes / What this PR does / Why we need it

Added a feature to switch settings according to the revision ID. This allows settings to be changed without breaking the display of past articles. Note that this does not affect each past edit summaries or individually transcluded templates (which settings are applied are determined solely by the revision ID of the page).

- derived from https://github.com/users/dummy-index/projects/1/views/1?pane=issue&itemId=145351219
- https://github.com/users/dummy-index/projects/1/views/1?pane=issue&itemId=145350499 (Since it includes a setting toggle feature, we want to stabilize the implementation of existing settings and reduce the need for changes in the future)


#### Checklist
<!-- Mark with [x] -->
- [x] `extension.json` version bumped

<!-- If this PR adds new variables or changes usage, please update README.md -->
