### PR TITLE
Text-mode improvement, and add sanitizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ wfLoadExtension( 'SimpleMathJax' );
 $wgSmjUseCdn = false;
 ```
 
-If you want to enable some extra inlineMath symbol pairs, set `$wgSmjExtraInlineMath`. Pairs of `[math][/math]` are always in-line math delimiters. (And independently of this setting, you can use `$ ... $` to switch to math mode within chemical formulas in the mhchem extension.)
+If you want to enable some extra inlineMath symbol pairs, set `$wgSmjExtraInlineMath`. Pairs of `[math][/math]` are always in-line math delimiters. (And independently of this setting, you can use `$ ... $` to switch to math mode within text (`\text{}` etc.) or chemical formulas (`\ce{}`).)
 ```PHP
 wfLoadExtension( 'SimpleMathJax' );
 $wgSmjExtraInlineMath = [["$","$"],["\\(","\\)"]];
@@ -66,13 +66,13 @@ wfLoadExtension( 'SimpleMathJax' );
 $wgSmjEnableMenu = false;
 ```
 
-Since version 0.8.8, by enabling `$wgSmjEnableHtmlAttributes`, the `display` attribute of the `<math>` tag will work, and the `class`, `id` and `title` attributes of the `<math>` tag will be carried over to the `<span>` tag.
+By enabling `$wgSmjEnableHtmlAttributes`, the `display` attribute of the `<math>` tag will work, and the `class`, `id`, `title` and `data-*` attributes of the `<math>` tag will be carried over to the `<span>` tag.
 ```PHP
 wfLoadExtension( 'SimpleMathJax' );
 $wgSmjEnableHtmlAttributes = true;
 ```
 
-In version 0.8.9, an option was added to make it completely dedicated to `<math>` and `<chem>`. Setting `$wgSmjDirectMathJax` to `env` disables `\ref{}` and escaping of `$`, while setting it to `none` disables all delimiters, including `[math]`, making it mandatory to enclose all TeX expressions in `<math>` or `<chem>` (and `$wgSmjDisplayMath`, `$wgSmjExtraInlineMath`, `$wgSmjIgnoreHtmlClass`, etc. will become meaningless).
+In version 0.8.9, an option was added to make it completely dedicated to `<math>` and `<chem>`. Setting `$wgSmjDirectMathJax` to `env` disables `\ref{}` and escaping of `$`, while setting it to `none` disables all delimiters, including `[math]`, making it mandatory to enclose all TeX expressions in `<math>` or `<chem>` (and `$wgSmjDisplayMath`, `$wgSmjExtraInlineMath`, and `$wgSmjIgnoreHtmlClass` will become meaningless).
 ```PHP
 wfLoadExtension( 'SimpleMathJax' );
 $wgSmjDirectMathJax = "none";
@@ -89,7 +89,7 @@ $wgSmjConfigByRevision = [
 ```
 
 # Hooks
-The hook `SimpleMathJaxAttributes` is available to add attributes to the span around the math. (Note that this process is performed only for `<math>` elements, and other delimiters are handled directly by MathJax.) This hook provides you with the opportunity to ensure that your own code does not interfere with MathJax's rendering of math.
+The hook `SimpleMathJaxAttributes` is available to add attributes to the span around the math. (Note that this process is performed only for `<math>` and `<chem>` elements, and other delimiters are handled directly by MathJax.) This hook provides you with the opportunity to ensure that your own code does not interfere with MathJax's rendering of math.
 
 For instance, if Lingo's JS functions are called before MathJax is invoked, then it is possible that Lingo will change the text so that MathJax could no longer render the math.
 

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -42,11 +42,6 @@ class SimpleMathJaxHooks {
 
 	public static function renderMath($tex, array $args, Parser $parser, PPFrame $frame ) {
 		if( !self::$enableHtmlAttributes ) $args = [];
-		if( !isset($args["chem"]) ) {
-			$tex = str_replace('\>', '\;', $tex);
-			$tex = str_replace('<', '\lt ', $tex);
-			$tex = str_replace('>', '\gt ', $tex);
-		}
 		if( isset($args["inline-block"]) ) {
 			if( isset($args["display"]) ) {
 				return self::renderError('SimpleMathJax: Do not use the inline-block attribute and the display attribute together on the same element.');

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -82,7 +82,8 @@ class SimpleMathJaxHooks {
 		$hookContainer = MediaWiki\MediaWikiServices::getInstance()->getHookContainer();
 		$attributes = [ "style" => "opacity:.5", "class" => "" ];
 		$inherit_tags = [ "class", "id", "title", "lang", "dir" ];
-		$attributes = array_merge( $attributes, Sanitizer::validateAttributes( $args , array_fill_keys( $inherit_tags, true ) ) );
+		$validatedAttribs = Sanitizer::validateAttributes( $args, array_fill_keys( $inherit_tags, true ) );
+	        $attributes = array_merge( $attributes, $validatedAttribs );
 
 		$hookContainer->run( "SimpleMathJaxAttributes", [ &$attributes, $tex, $args ] );
 		if( !isset($attributes["smj-debug"]) && !isset($args["smj-debug"]) ) {

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -12,12 +12,13 @@ class SimpleMathJaxHooks {
 			$wgSmjScale, $wgSmjDisplayAlign, $wgSmjWrapDisplaystyle,
 			$wgSmjEnableHtmlAttributes, $wgSmjConfigByRevision;
 
-		$globalvars = [ "wgSmjUseCdn", "wgSmjUseChem", "wgSmjDirectMathJax",
+		$globalvars = [ "wgSmjUseCdn", "wgSmjDirectMathJax",
 				"wgSmjDisplayMath", "wgSmjExtraInlineMath", "wgSmjIgnoreHtmlClass",
 				"wgSmjScale", "wgSmjEnableMenu", "wgSmjDisplayAlign" ];
 		foreach( $globalvars as $varname ) {
 			$wgOut->addJsConfigVars( $varname, $$varname );
 		}
+		self::$useChem = $wgSmjUseChem;
 		self::$wrapDisplaystyle = $wgSmjWrapDisplaystyle;
 		self::$enableHtmlAttributes = $wgSmjEnableHtmlAttributes;
 
@@ -30,10 +31,10 @@ class SimpleMathJaxHooks {
 			foreach( $globalvars as $varname ) {
 				if( isset($confset[$varname]) ) $wgOut->addJsConfigVars( $varname, $confset[$varname] );
 			}
+			if (isset($confset["wgSmjUseChem"]) ) self::$useChem = $confset["wgSmjUseChem"];
 			if (isset($confset["wgSmjWrapDisplaystyle"]) ) self::$wrapDisplaystyle = $confset["wgSmjWrapDisplaystyle"];
 			if (isset($confset["wgSmjEnableHtmlAttributes"]) ) self::$enableHtmlAttributes = $confset["wgSmjEnableHtmlAttributes"];
 		}
-		self::$useChem = $wgOut->getJsConfigVars()["wgSmjUseChem"];
 
 		$wgOut->addModules( [ 'ext.SimpleMathJax' ] );
 		$wgOut->addModules( [ 'ext.SimpleMathJax.mobile' ] ); // For MobileFrontend
@@ -43,7 +44,11 @@ class SimpleMathJaxHooks {
 	}
 
 	public static function renderMath($tex, array $args, Parser $parser, PPFrame $frame ) {
+		global $wgOut;
 		if( !self::$enableHtmlAttributes ) $args = [];
+		if( isset($args["chem"]) ) {
+			$wgOut->addJsConfigVars( "wgSmjPreloadChem", true );
+		}
 		if( isset($args["inline-block"]) ) {
 			if( isset($args["display"]) ) {
 				return self::renderError('SimpleMathJax: Do not use the inline-block attribute and the display attribute together on the same element.');
@@ -66,6 +71,8 @@ class SimpleMathJaxHooks {
 	}
 
 	public static function renderChem($tex, array $args, Parser $parser, PPFrame $frame ) {
+		global $wgOut;
+		$wgOut->addJsConfigVars( "wgSmjPreloadChem", true );
 		if( !self::$enableHtmlAttributes ) $args = [];
 		return self::renderTex("\\ce{ $tex }", $parser, $args);
 	}

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -1,5 +1,6 @@
 <?php
 use MediaWiki\Html\Html;
+use MediaWiki\Parser\Sanitizer;
 class SimpleMathJaxHooks {
 	private static $useChem;
 	private static $wrapDisplaystyle;
@@ -38,7 +39,8 @@ class SimpleMathJaxHooks {
 		$wgOut->addModules( [ 'ext.SimpleMathJax.mobile' ] ); // For MobileFrontend
 
 		$parser->setHook( 'math', __CLASS__ . '::renderMath' );
-		if( self::$useChem ) $parser->setHook( 'chem', __CLASS__ . '::renderChem' );	}
+		if( self::$useChem ) $parser->setHook( 'chem', __CLASS__ . '::renderChem' );
+	}
 
 	public static function renderMath($tex, array $args, Parser $parser, PPFrame $frame ) {
 		if( !self::$enableHtmlAttributes ) $args = [];
@@ -71,12 +73,10 @@ class SimpleMathJaxHooks {
 	private static function renderTex($tex, $parser, $args) {
 
 		$hookContainer = MediaWiki\MediaWikiServices::getInstance()->getHookContainer();
-		$attributes = [ "style" => "opacity:.5" ];
-		$attributes["class"] = ($args["class"] ?? '');
-		$inherit_tags = [ "id", "title", "lang", "dir" ];
-		foreach( $inherit_tags as $tag ) {
-			if( isset($args[$tag]) ) $attributes[$tag] = $args[$tag];
-		}
+		$attributes = [ "style" => "opacity:.5", "class" => "" ];
+		$inherit_tags = [ "class", "id", "title", "lang", "dir" ];
+		$attributes = array_merge( $attributes, Sanitizer::validateAttributes( $args , array_fill_keys( $inherit_tags, true ) ) );
+
 		$hookContainer->run( "SimpleMathJaxAttributes", [ &$attributes, $tex, $args ] );
 		if( !isset($attributes["smj-debug"]) && !isset($args["smj-debug"]) ) {
 			$attributes["class"] .= " smj-container";

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SimpleMathJax",
-	"version": "0.8.10",
+	"version": "0.8.11",
 	"author": "jmnote",
 	"url": "https://www.mediawiki.org/wiki/Extension:SimpleMathJax",
 	"description": "render TeX between <code><nowiki><math></nowiki></code> and <code><nowiki></math></nowiki></code>",

--- a/resources/ext.SimpleMathJax.js
+++ b/resources/ext.SimpleMathJax.js
@@ -6,7 +6,7 @@ window.MathJax = {
     processEnvironments: true,
     processRefs: mw.config.get('wgSmjDirectMathJax') == 'full',
     processEscapes: mw.config.get('wgSmjDirectMathJax') == 'full',
-    packages: mw.config.get('wgSmjUseChem') ? {'[+]': ['mhchem']} : {},
+    packages: mw.config.get('wgSmjPreloadChem') ? {'[+]': ['mhchem']} : {},
     macros: {
       AA: "{\u00c5}",
       alef: "{\\aleph}",
@@ -123,7 +123,7 @@ window.MathJax = {
     displayAlign: mw.config.get('wgSmjDisplayAlign')
   },
   loader: {
-    load: mw.config.get('wgSmjUseChem') ? ['ui/safe', '[tex]/mhchem'] : ['ui/safe']
+    load: mw.config.exists('wgSmjPreloadChem') ? ['ui/safe', '[tex]/mhchem'] : ['ui/safe']
   },
   startup: {
     elements: mw.config.get('wgSmjDirectMathJax') == 'none' ? ["span.smj-container"] : null,

--- a/resources/ext.SimpleMathJax.js
+++ b/resources/ext.SimpleMathJax.js
@@ -123,7 +123,7 @@ window.MathJax = {
     displayAlign: mw.config.get('wgSmjDisplayAlign')
   },
   loader: {
-    load: mw.config.get('wgSmjUseChem') ? ['[tex]/mhchem'] : []
+    load: mw.config.get('wgSmjUseChem') ? ['ui/safe', '[tex]/mhchem'] : ['ui/safe']
   },
   startup: {
     elements: mw.config.get('wgSmjDirectMathJax') == 'none' ? ["span.smj-container"] : null,

--- a/resources/ext.SimpleMathJax.js
+++ b/resources/ext.SimpleMathJax.js
@@ -6,7 +6,7 @@ window.MathJax = {
     processEnvironments: true,
     processRefs: mw.config.get('wgSmjDirectMathJax') == 'full',
     processEscapes: mw.config.get('wgSmjDirectMathJax') == 'full',
-    packages: mw.config.get('wgSmjPreloadChem') ? {'[+]': ['mhchem']} : {},
+    packages: mw.config.exists('wgSmjPreloadChem') ? {'[+]': ['autoload','mhchem']} : {'[+]': ['autoload']},
     macros: {
       AA: "{\u00c5}",
       alef: "{\\aleph}",
@@ -123,7 +123,7 @@ window.MathJax = {
     displayAlign: mw.config.get('wgSmjDisplayAlign')
   },
   loader: {
-    load: mw.config.exists('wgSmjPreloadChem') ? ['ui/safe', '[tex]/mhchem'] : ['ui/safe']
+    load: ['ui/safe','[tex]/autoload'].concat(mw.config.exists('wgSmjPreloadChem') ? ['[tex]/mhchem'] : [])
   },
   startup: {
     elements: mw.config.get('wgSmjDirectMathJax') == 'none' ? ["span.smj-container"] : null,


### PR DESCRIPTION
#### Which issue this PR fixes / What this PR does / Why we need it

The three str_replace() calls cause problems with `text{}` and `ce{}`, so they will be removed.
The built-in sanitizer in MathJax will be enabled.

- fixes #58


#### Checklist
<!-- Mark with [x] -->
- [x] `extension.json` version bumped

<!-- If this PR adds new variables or changes usage, please update README.md -->
