### PR TITLE
updated local MathJax reference to it's branch "legacy-v3" / tag: 3.2.2

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SimpleMathJax",
-	"version": "0.8.11",
+	"version": "0.8.12",
 	"author": "jmnote",
 	"url": "https://www.mediawiki.org/wiki/Extension:SimpleMathJax",
 	"description": "render TeX between <code><nowiki><math></nowiki></code> and <code><nowiki></math></nowiki></code>",


### PR DESCRIPTION
This mirrors the version currently served at https://cdn.jsdelivr.net/npm/mathjax@3

- works for me with MediaWiki 1.43.8


#### Checklist
<!-- Mark with [x] -->
- [ x] `extension.json` version bumped

<!-- If this PR adds new variables or changes usage, please update README.md -->
