### PR TITLE
Lazy load MathJax scripts when direct parsing is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The SimpleMathJax extension enables MathJax, a Javascript library, for typesetting TeX formula in MediaWiki inside math environments.
+The SimpleMathJax extension enables MathJax, a Javascript library, for typesetting TeX formula in MediaWiki inside math environments. It requires MediaWiki 1.43 or later.
 
 https://www.mediawiki.org/wiki/Extension:SimpleMathJax
 
@@ -31,7 +31,7 @@ wfLoadExtension( 'SimpleMathJax' );
 | `$wgSmjExtraInlineMath`  | MathJax.tex.inlineMath           | []                        | [['\\(', '\\)']]            |
 | `$wgSmjIgnoreHtmlClass`  | MathJax.options.ignoreHtmlClass  | "mathjax_ignore\|comment\|<br>diff-(context\|<br>addedline\|deletedline)" | "mathjax_ignore" |
 | `$wgSmjScale`            | MathJax.chtml.scale              | 1                         | 1.5                         |
-| `$wgSmjDisplayAlign`     | MathJax.chtml.displayAlign       | "center"                  | "left"                      |
+| `$wgSmjDisplayAlign`     | MathJax.chtml.displayAlign       | "left"                    | "center"                    |
 | `$wgSmjWrapDisplaystyle` | wrap with displaystyle on `<math>`  | true                   | false                       |
 | `$wgSmjEnableHtmlAttributes` | process attributes of math tag  | false                  | true                        |
 | `$wgSmjConfigByRevision` | switch the configuration according to the article's revision  | [] | [['upto'=>1048576,<br>'wgSmjDisplayAlign'<br>=>'left']] |

--- a/SimpleMathJax.php
+++ b/SimpleMathJax.php
@@ -7,5 +7,5 @@ if ( function_exists( 'wfLoadExtension' ) ) {
 	);
 	return true;
 } else {
-	die( 'This version of the SimpleMathJax extension requires MediaWiki 1.25+' );
+	die( 'This version of the SimpleMathJax extension requires MediaWiki 1.43+' );
 }

--- a/SimpleMathJaxHooks.php
+++ b/SimpleMathJaxHooks.php
@@ -12,15 +12,19 @@ class SimpleMathJaxHooks {
 			$wgSmjScale, $wgSmjDisplayAlign, $wgSmjWrapDisplaystyle,
 			$wgSmjEnableHtmlAttributes, $wgSmjConfigByRevision;
 
-		$globalvars = [ "wgSmjUseCdn", "wgSmjDirectMathJax",
-				"wgSmjDisplayMath", "wgSmjExtraInlineMath", "wgSmjIgnoreHtmlClass",
-				"wgSmjScale", "wgSmjEnableMenu", "wgSmjDisplayAlign" ];
-		foreach( $globalvars as $varname ) {
-			$wgOut->addJsConfigVars( $varname, $$varname );
-		}
-		self::$useChem = $wgSmjUseChem;
-		self::$wrapDisplaystyle = $wgSmjWrapDisplaystyle;
-		self::$enableHtmlAttributes = $wgSmjEnableHtmlAttributes;
+		$config = [
+			"wgSmjUseCdn" => $wgSmjUseCdn,
+			"wgSmjUseChem" => $wgSmjUseChem,
+			"wgSmjDirectMathJax" => $wgSmjDirectMathJax,
+			"wgSmjDisplayMath" => $wgSmjDisplayMath,
+			"wgSmjExtraInlineMath" => $wgSmjExtraInlineMath,
+			"wgSmjIgnoreHtmlClass" => $wgSmjIgnoreHtmlClass,
+			"wgSmjScale" => $wgSmjScale,
+			"wgSmjEnableMenu" => $wgSmjEnableMenu,
+			"wgSmjDisplayAlign" => $wgSmjDisplayAlign,
+			"wgSmjWrapDisplaystyle" => $wgSmjWrapDisplaystyle,
+			"wgSmjEnableHtmlAttributes" => $wgSmjEnableHtmlAttributes,
+		];
 
 		$articlerev = (int)$wgOut->getRevisionId();
 		foreach ($wgSmjConfigByRevision as $confset) {
@@ -28,26 +32,36 @@ class SimpleMathJaxHooks {
 			if (!isset($confset["upto"]) && !isset($confset["since"])) continue;
 			if (isset($confset["upto"]) && $confset["upto"] < $articlerev) continue;
 			if (isset($confset["since"]) && $confset["since"] > $articlerev) continue;
-			foreach( $globalvars as $varname ) {
-				if( isset($confset[$varname]) ) $wgOut->addJsConfigVars( $varname, $confset[$varname] );
+			foreach( array_keys( $config ) as $varname ) {
+				if( array_key_exists($varname, $confset) ) $config[$varname] = $confset[$varname];
 			}
-			if (isset($confset["wgSmjUseChem"]) ) self::$useChem = $confset["wgSmjUseChem"];
-			if (isset($confset["wgSmjWrapDisplaystyle"]) ) self::$wrapDisplaystyle = $confset["wgSmjWrapDisplaystyle"];
-			if (isset($confset["wgSmjEnableHtmlAttributes"]) ) self::$enableHtmlAttributes = $confset["wgSmjEnableHtmlAttributes"];
 		}
 
-		$wgOut->addModules( [ 'ext.SimpleMathJax' ] );
-		$wgOut->addModules( [ 'ext.SimpleMathJax.mobile' ] ); // For MobileFrontend
+		$clientConfigVars = [ "wgSmjUseCdn", "wgSmjDirectMathJax",
+				"wgSmjDisplayMath", "wgSmjExtraInlineMath", "wgSmjIgnoreHtmlClass",
+				"wgSmjScale", "wgSmjEnableMenu", "wgSmjDisplayAlign" ];
+		foreach( $clientConfigVars as $varname ) {
+			$wgOut->addJsConfigVars( $varname, $config[$varname] );
+		}
+
+		self::$useChem = $config["wgSmjUseChem"];
+		self::$wrapDisplaystyle = $config["wgSmjWrapDisplaystyle"];
+		self::$enableHtmlAttributes = $config["wgSmjEnableHtmlAttributes"];
+
+		if ( $config["wgSmjDirectMathJax"] !== 'none' ) {
+			$wgOut->addModules( [ 'ext.SimpleMathJax' ] );
+		}
 
 		$parser->setHook( 'math', __CLASS__ . '::renderMath' );
 		if( self::$useChem ) $parser->setHook( 'chem', __CLASS__ . '::renderChem' );
 	}
 
 	public static function renderMath($tex, array $args, Parser $parser, PPFrame $frame ) {
-		global $wgOut;
+		$parserOutput = $parser->getOutput();
+		$parserOutput->addModules( [ 'ext.SimpleMathJax' ] );
 		if( !self::$enableHtmlAttributes ) $args = [];
 		if( isset($args["chem"]) ) {
-			$wgOut->addJsConfigVars( "wgSmjPreloadChem", true );
+			$parserOutput->setJsConfigVar( "wgSmjPreloadChem", true );
 		}
 		if( isset($args["inline-block"]) ) {
 			if( isset($args["display"]) ) {
@@ -71,8 +85,9 @@ class SimpleMathJaxHooks {
 	}
 
 	public static function renderChem($tex, array $args, Parser $parser, PPFrame $frame ) {
-		global $wgOut;
-		$wgOut->addJsConfigVars( "wgSmjPreloadChem", true );
+		$parserOutput = $parser->getOutput();
+		$parserOutput->addModules( [ 'ext.SimpleMathJax' ] );
+		$parserOutput->setJsConfigVar( "wgSmjPreloadChem", true );
 		if( !self::$enableHtmlAttributes ) $args = [];
 		return self::renderTex("\\ce{ $tex }", $parser, $args);
 	}
@@ -83,7 +98,7 @@ class SimpleMathJaxHooks {
 		$attributes = [ "style" => "opacity:.5", "class" => "" ];
 		$inherit_tags = [ "class", "id", "title", "lang", "dir" ];
 		$validatedAttribs = Sanitizer::validateAttributes( $args, array_fill_keys( $inherit_tags, true ) );
-	        $attributes = array_merge( $attributes, $validatedAttribs );
+		$attributes = array_merge( $attributes, $validatedAttribs );
 
 		$hookContainer->run( "SimpleMathJaxAttributes", [ &$attributes, $tex, $args ] );
 		if( !isset($attributes["smj-debug"]) && !isset($args["smj-debug"]) ) {

--- a/extension.json
+++ b/extension.json
@@ -1,35 +1,37 @@
 {
 	"name": "SimpleMathJax",
-	"version": "0.8.12",
+	"version": "0.9.0",
 	"author": "jmnote",
 	"url": "https://www.mediawiki.org/wiki/Extension:SimpleMathJax",
 	"description": "render TeX between <code><nowiki><math></nowiki></code> and <code><nowiki></math></nowiki></code>",
 	"license-name": "GPL-2.0+",
 	"type": "parserhook",
+	"requires": {
+		"MediaWiki": ">= 1.43.0"
+	},
 	"AutoloadClasses": {
 		"SimpleMathJaxHooks": "SimpleMathJaxHooks.php"
 	},
 	"config": {
-		"SmjUseCdn": {"value":true, "description":"true to load mathjax from CDN"},
-		"SmjUseChem": {"value":true, "description":"true to enabled chem tag"},
-		"SmjDirectMathJax": {"value":"full", "description":"env to disable escapes, none to only math and chem tags"},
-		"SmjDisplayMath": {"value":[], "description":"MathJax.tex.displayMath"},
-		"SmjExtraInlineMath": {"value":[], "description":"MathJax.tex.inlineMath"},
-		"SmjIgnoreHtmlClass": {"value":"mathjax_ignore|comment|diff-(context|addedline|deletedline)", "description":"MathJax.options.ignoreHtmlClass"},
-		"SmjScale": {"value":1, "description":"MathJax.chtml.scale"},
-		"SmjEnableMenu": {"value":true, "description":"MathJax.options.enableMenu"},
-		"SmjDisplayAlign": {"value":"left", "description":"MathJax.chtml.displayAlign"},
-		"SmjWrapDisplaystyle": {"value":true, "description":"true to wrap with displaystyle"},
-		"SmjEnableHtmlAttributes": {"value":false, "description":"true to process attributes of math tag"},
-		"SmjConfigByRevision": {"value":[], "description":"switch the configuration"}
+		"SmjUseCdn": {"value":true, "description":"Whether to load MathJax from CDN"},
+		"SmjUseChem": {"value":true, "description":"Whether to enable <chem> tag"},
+		"SmjDirectMathJax": {"value":"full", "description":"Direct MathJax mode: 'full', 'env', or 'none' (lazy load)"},
+		"SmjDisplayMath": {"value":[], "description":"Delimiters for MathJax.tex.displayMath"},
+		"SmjExtraInlineMath": {"value":[], "description":"Delimiters for MathJax.tex.inlineMath"},
+		"SmjIgnoreHtmlClass": {"value":"mathjax_ignore|comment|diff-(context|addedline|deletedline)", "description":"Pattern for MathJax.options.ignoreHtmlClass"},
+		"SmjScale": {"value":1, "description":"Output scale for MathJax.chtml.scale"},
+		"SmjEnableMenu": {"value":true, "description":"Whether to enable MathJax context menu"},
+		"SmjDisplayAlign": {"value":"left", "description":"Alignment for MathJax.chtml.displayAlign"},
+		"SmjWrapDisplaystyle": {"value":true, "description":"Whether to wrap <math> in displaystyle"},
+		"SmjEnableHtmlAttributes": {"value":false, "description":"Whether to process HTML attributes on <math>"},
+		"SmjConfigByRevision": {"value":[], "description":"Revision-based configuration overrides"}
 	},
 	"Hooks": {
 		"ParserFirstCallInit": "SimpleMathJaxHooks::onParserFirstCallInit"
 	},
 	"ResourceModules": {
 		"ext.SimpleMathJax": {
-			"scripts": ["resources/ext.SimpleMathJax.js"],
-			"targets": ["desktop", "mobile"]
+			"scripts": ["resources/ext.SimpleMathJax.js"]
 		}
 	},
 	"ResourceFileModulePaths": {


### PR DESCRIPTION
#### What this PR does / Why we need it

Lazy load MathJax scripts when direct parsing is disabled

#### Checklist
<!-- Mark with [x] -->
- [x] `extension.json` version bumped

<!-- If this PR adds new variables or changes usage, please update README.md -->
